### PR TITLE
[protocol handler]: add ability to open gists

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,11 @@
-## v0.0.16 (12/08/2019)
-
-- Add the ability to open gists with protocol handler:
-  
-  - `Using gist Id`: vscode://vsls-contrib.gistfs/open-gist?id=b01737ed99192dab436adea1d6d92975
-  - `Using gist URL`: vscode://vsls-contrib.gistfs/open-gist-url?url=https://gist.github.com/legomushroom/b01737ed99192dab436adea1d6d92975
-
 ## v0.0.15 (12/08/2019)
 
-- Added support for opening image files in a Gist
-  
+- Added support for opening image files in a Gist.
+- Add the ability to open gists with protocol handler:
+
+  - `Using gist URL`: vscode://vsls-contrib.gistfs/open-gist?url=https://gist.github.com/legomushroom/b01737ed99192dab436adea1d6d92975
+  - `Using gist Id`: vscode://vsls-contrib.gistfs/open-gist?id=b01737ed99192dab436adea1d6d92975
+
 ## v0.0.14 (12/07/2019)
 
 - 🖼️ Implement the `Paste Screenshot` command that allows to paste a screenshot from your clipboard into the gist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.0.16 (12/08/2019)
 
-- Add the ability to open gits with protocol handler:
+- Add the ability to open gists with protocol handler:
   
   - `Using gist Id`: vscode://vsls-contrib.gistfs/open-gist?id=b01737ed99192dab436adea1d6d92975
   - `Using gist URL`: vscode://vsls-contrib.gistfs/open-gist-url?url=https://gist.github.com/legomushroom/b01737ed99192dab436adea1d6d92975

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.0.16 (12/08/2019)
+
+- Add the ability to open gits with protocol handler:
+  
+  - `Using gist Id`: vscode://vsls-contrib.gistfs/open-gist?id=b01737ed99192dab436adea1d6d92975
+  - `Using gist URL`: vscode://vsls-contrib.gistfs/open-gist-url?url=https://gist.github.com/legomushroom/b01737ed99192dab436adea1d6d92975
+
 ## v0.0.15 (12/08/2019)
 
 - Added support for opening image files in a Gist

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "GistPad",
   "description": "Browse, edit and fork GitHub Gists, directly within Visual Studio Code",
   "publisher": "vsls-contrib",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "icon": "images/icon.png",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,7 @@ export const EXTENSION_ID = "gistpad";
 export const FS_SCHEME = "gist";
 export const UNTITLED_SCHEME = "untitled";
 export const ZERO_WIDTH_SPACE = "‎‎\u200B";
+
+export const CommandId = {
+    openGist: `${EXTENSION_ID}.openGist`
+} as const;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { registerCommands } from "./commands";
 import { registerCommentController } from "./comments";
 import { registerFileSystemProvider } from "./fileSystem";
 import { log } from "./logger";
+import { initializeProtocolHander } from "./protocolHandler";
 import { store } from "./store";
 import { initializeAuth } from "./store/auth";
 import { initializeStorage } from "./store/storage";
@@ -11,7 +12,9 @@ import { registerTreeProvider } from "./tree";
 export async function activate(context: vscode.ExtensionContext) {
   try {
     log.setLoggingChannel(vscode.window.createOutputChannel('GistPad'));
+
     initializeAuth();
+    initializeProtocolHander();
 
     registerCommands(context);
     registerFileSystemProvider(store);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,7 +11,7 @@ export class Log {
     }
 
     const time = new Date();
-    this.channel.appendLine(`[${time.toUTCString()}] ${message}`);
+    this.channel.appendLine(`[${type}][${time.toUTCString()}] ${message}`);
   }
 
   public info = (message: string) => {

--- a/src/protocolHandler.ts
+++ b/src/protocolHandler.ts
@@ -1,46 +1,40 @@
-import { URLSearchParams } from 'url';
-import * as vscode from 'vscode';
-import { CommandId } from './constants';
-import { log } from './logger';
+import { URLSearchParams } from "url";
+import * as vscode from "vscode";
+import { CommandId } from "./constants";
+import { log } from "./logger";
 
 const getQuery = (uri: vscode.Uri): URLSearchParams => {
   const query = new URLSearchParams(uri.query);
 
   return query;
-}
+};
 
-const openGistFactory = (paramName: 'id' | 'url') => {
-  return async (uri: vscode.Uri) => {
-    const query = getQuery(uri);
+const openGist = async (uri: vscode.Uri) => {
+  const query = getQuery(uri);
 
-    const gistParam = query.get(paramName);
+  const gistUrl = query.get("url");
+  const gistId = query.get("id");
+  const openAsWorkspace = query.get("workspace") === "true";
 
-    if (!gistParam) {
-      log.error(`No gist ${paramName} specified in "${uri}"`);
-      throw new Error(`No gist ${paramName} specified.`);
-    }
-
-    const propName = (paramName === 'id')
-      ? 'gistId'
-      : 'gistUrl'
-
-    await vscode.commands.executeCommand(CommandId.openGist, { [propName]: gistParam });
+  if (!gistUrl && !gistId) {
+    const message = `No gist URL nor Id specified in "${uri}"`;
+    log.error(message);
+    throw new Error(message);
   }
-}
+
+  const options = gistUrl ? { gistUrl } : { gistId };
+
+  await vscode.commands.executeCommand(CommandId.openGist, {
+    ...options,
+    openAsWorkspace,
+  });
+};
 
 export class GistPadProtocolHandler implements vscode.UriHandler {
   public async handleUri(uri: vscode.Uri): Promise<void> {
     switch (uri.path) {
-      case '/open-gist': {
-        const openGist = openGistFactory('id');
-
+      case "/open-gist": {
         return await openGist(uri);
-      }
-
-      case '/open-gist-url': {
-        const openGistUrl = openGistFactory('url')
-
-        return await openGistUrl(uri);
       }
 
       default: {
@@ -49,12 +43,12 @@ export class GistPadProtocolHandler implements vscode.UriHandler {
     }
   }
 
-  public dispose(): void { }
+  public dispose(): void {}
 }
 
 export const initializeProtocolHander = () => {
-  if (typeof vscode.window.registerUriHandler === 'function') {
-    log.info('Protocol handler is registered.');
-    vscode.window.registerUriHandler(new GistPadProtocolHandler);
+  if (typeof vscode.window.registerUriHandler === "function") {
+    log.info("Protocol handler is registered.");
+    vscode.window.registerUriHandler(new GistPadProtocolHandler());
   }
-}
+};

--- a/src/protocolHandler.ts
+++ b/src/protocolHandler.ts
@@ -1,0 +1,60 @@
+import { URLSearchParams } from 'url';
+import * as vscode from 'vscode';
+import { CommandId } from './constants';
+import { log } from './logger';
+
+const getQuery = (uri: vscode.Uri): URLSearchParams => {
+  const query = new URLSearchParams(uri.query);
+
+  return query;
+}
+
+const openGistFactory = (paramName: 'id' | 'url') => {
+  return async (uri: vscode.Uri) => {
+    const query = getQuery(uri);
+
+    const gistParam = query.get(paramName);
+
+    if (!gistParam) {
+      log.error(`No gist ${paramName} specified in "${uri}"`);
+      throw new Error(`No gist ${paramName} specified.`);
+    }
+
+    const propName = (paramName === 'id')
+      ? 'gistId'
+      : 'gistUrl'
+
+    await vscode.commands.executeCommand(CommandId.openGist, { [propName]: gistParam });
+  }
+}
+
+export class GistPadProtocolHandler implements vscode.UriHandler {
+  public async handleUri(uri: vscode.Uri): Promise<void> {
+    switch (uri.path) {
+      case '/open-gist': {
+        const openGist = openGistFactory('id');
+
+        return await openGist(uri);
+      }
+
+      case '/open-gist-url': {
+        const openGistUrl = openGistFactory('url')
+
+        return await openGistUrl(uri);
+      }
+
+      default: {
+        break;
+      }
+    }
+  }
+
+  public dispose(): void { }
+}
+
+export const initializeProtocolHander = () => {
+  if (typeof vscode.window.registerUriHandler === 'function') {
+    log.info('Protocol handler is registered.');
+    vscode.window.registerUriHandler(new GistPadProtocolHandler);
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,7 @@
 import axios from "axios";
 import * as moment from "moment";
 import * as path from "path";
-import {
-  commands,
-  TextDocument,
-  Uri,
-  ViewColumn,
-  window,
-  workspace
-} from "vscode";
+import { commands, TextDocument, Uri, ViewColumn, window, workspace } from "vscode";
 import { FS_SCHEME } from "./constants";
 import { Gist, GistFile } from "./store";
 import { getGist } from "./store/actions";
@@ -45,7 +38,7 @@ export function getGistDetailsFromUri(uri: Uri) {
 export function getGistDescription(gist: Gist): string {
   return `${moment(gist.updated_at).calendar()}${
     gist.public ? "" : " (Secret)"
-  }`;
+    }`;
 }
 
 export function getGistLabel(gist: Gist): string {


### PR DESCRIPTION
The PR adds protocol handler and to routes to open gists:

  - `Using gist Id`: vscode://vsls-contrib.gistfs/open-gist?id=b01737ed99192dab436adea1d6d92975
  - `Using gist URL`: vscode://vsls-contrib.gistfs/open-gist-url?url=https://gist.github.com/legomushroom/b01737ed99192dab436adea1d6d92975
