### PR TITLE
In the browser, the scope header is returned with lower case. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Browse, edit and fork GitHub Gists, directly within Visual Studio Code",
   "publisher": "vsls-contrib",
   "version": "0.0.25",
+  "extensionKind": [
+    "web",
+    "workspace"
+  ],
   "icon": "images/icon.png",
   "repository": {
     "type": "git",

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -33,7 +33,7 @@ const STATE_CONTEXT_KEY = `${EXTENSION_ID}:state`;
 const STATE_SIGNED_IN = "SignedIn";
 const STATE_SIGNED_OUT = "SignedOut";
 
-const SCOPE_HEADER = "X-OAuth-Scopes";
+const SCOPE_HEADER = "x-oauth-scopes";
 const GIST_SCOPE = "gist";
 
 async function testToken(token: string) {
@@ -41,7 +41,9 @@ async function testToken(token: string) {
   const github = new GitHub({ apiurl, token });
   try {
     const response = await github.get("/user");
-    const scopeHeaderIndex = response.rawHeaders.indexOf(SCOPE_HEADER);
+    const scopeHeaderIndex = response.rawHeaders.findIndex(
+      (item: string) => item.toLowerCase() === SCOPE_HEADER
+    );
     if (scopeHeaderIndex === -1) {
       return false;
     }


### PR DESCRIPTION
Make the check case insensitive. 

Also setting extensionkind in the package.json