### PR TITLE
Split out auth across desktop and browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "onCommand:gistpad.starredGists",
     "onFileSystem:gist",
     "onView:gistpad.gists",
+    "onUri",
     "*"
   ],
   "main": "./out/prod/extension.js",

--- a/src/abstractions/browser/signIn.ts
+++ b/src/abstractions/browser/signIn.ts
@@ -1,0 +1,10 @@
+import * as vscode from "vscode";
+
+export async function performSignInFlow() {
+  const callableUri = await vscode.env.asExternalUri(
+    vscode.Uri.parse(
+      `${vscode.env.uriScheme}://vsls-contrib.gistfs/did-authenticate`
+    )
+  );
+  await vscode.env.openExternal(callableUri);
+}

--- a/src/abstractions/browser/signIn.ts
+++ b/src/abstractions/browser/signIn.ts
@@ -1,10 +1,13 @@
 import * as vscode from "vscode";
 
-export async function performSignInFlow() {
+export async function performSignInFlow(): Promise<string | undefined> {
   const callableUri = await vscode.env.asExternalUri(
     vscode.Uri.parse(
       `${vscode.env.uriScheme}://vsls-contrib.gistfs/did-authenticate`
     )
   );
   await vscode.env.openExternal(callableUri);
+
+  // Return empty token since the url handler will fetch token from keytar and initialize auth.
+  return;
 }

--- a/src/abstractions/node/signIn.ts
+++ b/src/abstractions/node/signIn.ts
@@ -1,0 +1,11 @@
+import { env, window } from "vscode";
+
+export async function performSignInFlow() {
+  const value = await env.clipboard.readText();
+  const token = await window.showInputBox({
+    prompt: "Enter your GitHub token",
+    value
+  });
+
+  return token;
+}

--- a/src/abstractions/node/signIn.ts
+++ b/src/abstractions/node/signIn.ts
@@ -1,6 +1,6 @@
 import { env, window } from "vscode";
 
-export async function performSignInFlow() {
+export async function performSignInFlow(): Promise<string | undefined> {
   const value = await env.clipboard.readText();
   const token = await window.showInputBox({
     prompt: "Enter your GitHub token",

--- a/src/protocolHandler.ts
+++ b/src/protocolHandler.ts
@@ -2,7 +2,7 @@ import { URLSearchParams } from "url";
 import * as vscode from "vscode";
 import { CommandId } from "./constants";
 import { log } from "./logger";
-import { getToken, markUserAsSignedIn, testToken } from "./store/auth";
+import { initializeAuth } from "./store/auth";
 
 const getQuery = (uri: vscode.Uri): URLSearchParams => {
   const query = new URLSearchParams(uri.query);
@@ -33,20 +33,12 @@ const openGist = async (uri: vscode.Uri) => {
 
 export class GistPadProtocolHandler implements vscode.UriHandler {
   public async handleUri(uri: vscode.Uri): Promise<void> {
-    console.log("handling");
     switch (uri.path) {
       case "/open-gist": {
         return await openGist(uri);
       }
       case "/did-authenticate": {
-        console.log("called!");
-        const currentToken = await getToken();
-        console.log(currentToken);
-        if (currentToken && (await testToken(currentToken))) {
-          await markUserAsSignedIn();
-        } else {
-          vscode.window.showErrorMessage("Failed to get a valid GitHub token");
-        }
+        await initializeAuth();
       }
       default: {
         break;

--- a/src/protocolHandler.ts
+++ b/src/protocolHandler.ts
@@ -2,6 +2,7 @@ import { URLSearchParams } from "url";
 import * as vscode from "vscode";
 import { CommandId } from "./constants";
 import { log } from "./logger";
+import { getToken, markUserAsSignedIn, testToken } from "./store/auth";
 
 const getQuery = (uri: vscode.Uri): URLSearchParams => {
   const query = new URLSearchParams(uri.query);
@@ -26,17 +27,27 @@ const openGist = async (uri: vscode.Uri) => {
 
   await vscode.commands.executeCommand(CommandId.openGist, {
     ...options,
-    openAsWorkspace,
+    openAsWorkspace
   });
 };
 
 export class GistPadProtocolHandler implements vscode.UriHandler {
   public async handleUri(uri: vscode.Uri): Promise<void> {
+    console.log("handling");
     switch (uri.path) {
       case "/open-gist": {
         return await openGist(uri);
       }
-
+      case "/did-authenticate": {
+        console.log("called!");
+        const currentToken = await getToken();
+        console.log(currentToken);
+        if (currentToken && (await testToken(currentToken))) {
+          await markUserAsSignedIn();
+        } else {
+          vscode.window.showErrorMessage("Failed to get a valid GitHub token");
+        }
+      }
       default: {
         break;
       }


### PR DESCRIPTION
Add an abstraction for the sign in flow so that the clicking signin can trigger a browser based auth flow.