### PR TITLE
Add functionality for viewing forks of Gist

### DIFF
--- a/package.json
+++ b/package.json
@@ -878,7 +878,7 @@
         {
           "command": "gistpad.unstarGist",
           "when": "viewItem =~ /^starredGists.gist/",
-          "group": "star@1"
+          "group": "star@2"
         },
         {
           "command": "gistpad.viewForks",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "onCommand:gistpad.signIn",
     "onCommand:gistpad.signOut",
     "onCommand:gistpad.starredGists",
-    "onCommand:gistpad.viewForkedGist",
+    "onCommand:gistpad.viewForks",
     "onFileSystem:gist",
     "onView:gistpad.gists",
     "onView:gistpad.gists.explorer",
@@ -523,8 +523,8 @@
         "category": "GistPad"
       },
       {
-        "command": "gistpad.viewForkedGist",
-        "title": "View Forked Gist",
+        "command": "gistpad.viewForks",
+        "title": "View Fork(s)",
         "category": "GistPad"
       }
     ],
@@ -723,7 +723,7 @@
           "when": "false"
         },
         {
-          "command": "gistpad.viewForkedGist",
+          "command": "gistpad.viewForks",
           "when": "false"
         }
       ],
@@ -881,9 +881,14 @@
           "group": "star@1"
         },
         {
+          "command": "gistpad.viewForks",
+          "when": "viewItem =~ /^gists.gist/",
+          "group": "star@1"
+        },
+        {
           "command": "gistpad.starGist",
           "when": "viewItem =~ /^(gists|followedUser).gist/",
-          "group": "star@1"
+          "group": "star@2"
         },
         {
           "command": "gistpad.unfollowUser",
@@ -904,11 +909,6 @@
           "command": "gistpad.addFileToGist",
           "when": "viewItem =~ /^gistFile/",
           "group": "base@3"
-        },
-        {
-          "command": "gistpad.viewForkedGist",
-          "when": "viewItem =~ /^gists.gist/",
-          "group": "fork@1"
         },
         {
           "command": "gistpad.renameFile",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "onCommand:gistpad.signIn",
     "onCommand:gistpad.signOut",
     "onCommand:gistpad.starredGists",
+    "onCommand:gistpad.viewForkedGist",
     "onFileSystem:gist",
     "onView:gistpad.gists",
     "onView:gistpad.gists.explorer",
@@ -520,6 +521,11 @@
         "command": "gistpad.uploadFileToGist",
         "title": "Upload File(s)",
         "category": "GistPad"
+      },
+      {
+        "command": "gistpad.viewForkedGist",
+        "title": "View Forked Gist",
+        "category": "GistPad"
       }
     ],
     "menus": {
@@ -715,6 +721,10 @@
         {
           "command": "gistpad.unstarGist",
           "when": "false"
+        },
+        {
+          "command": "gistpad.viewForkedGist",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -894,6 +904,11 @@
           "command": "gistpad.addFileToGist",
           "when": "viewItem =~ /^gistFile/",
           "group": "base@3"
+        },
+        {
+          "command": "gistpad.viewForkedGist",
+          "when": "viewItem =~ /^gists.gist/",
+          "group": "fork@1"
         },
         {
           "command": "gistpad.renameFile",

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -1,14 +1,50 @@
 import { runInAction } from "mobx";
 import { URL } from "url";
-import { commands, env, ExtensionContext, ProgressLocation, QuickPickItem, Uri, window, workspace } from "vscode";
+import {
+  commands,
+  env,
+  ExtensionContext,
+  ProgressLocation,
+  QuickPickItem,
+  Uri,
+  window,
+  workspace
+} from "vscode";
 import { EXTENSION_NAME } from "../constants";
 import { log } from "../logger";
 import { GistFile, SortOrder, store } from "../store";
-import { changeDescription, deleteGist, forkGist, getForks, newGist, refreshGists, starGist, starredGists, unstarGist } from "../store/actions";
+import {
+  changeDescription,
+  deleteGist,
+  forkGist,
+  getForks,
+  newGist,
+  refreshGists,
+  starGist,
+  starredGists,
+  unstarGist
+} from "../store/actions";
 import { ensureAuthenticated, isAuthenticated, signIn } from "../store/auth";
-import { FollowedUserGistNode, GistNode, GistsNode, StarredGistNode } from "../tree/nodes";
+import {
+  FollowedUserGistNode,
+  GistNode,
+  GistsNode,
+  StarredGistNode
+} from "../tree/nodes";
 import { createGistPadOpenUrl } from "../uriHandler";
-import { byteArrayToString, closeGistFiles, fileNameToUri, getGistDescription, getGistLabel, getGistWorkspaceId, isGistWorkspace, openGist, openGistFiles, sortGists, withProgress } from "../utils";
+import {
+  byteArrayToString,
+  closeGistFiles,
+  fileNameToUri,
+  getGistDescription,
+  getGistLabel,
+  getGistWorkspaceId,
+  isGistWorkspace,
+  openGist,
+  openGistFiles,
+  sortGists,
+  withProgress
+} from "../utils";
 const GIST_NAME_PATTERN = /(\/)?(?<owner>([a-z\d]+-)*[a-z\d]+)\/(?<id>[^\/]+)$/i;
 
 export interface GistQuickPickItem extends QuickPickItem {
@@ -250,7 +286,7 @@ export async function registerGistCommands(context: ExtensionContext) {
         // in it, and the API doesn't support that URL format
         const url = `https://gist.github.com/${node.gist.owner!.login}/${
           node.gist.id
-          }`;
+        }`;
         env.clipboard.writeText(url);
       }
     )
@@ -368,15 +404,13 @@ export async function registerGistCommands(context: ExtensionContext) {
 
   context.subscriptions.push(
     commands.registerCommand(
-      `${EXTENSION_NAME}.viewForkedGist`,
+      `${EXTENSION_NAME}.viewForks`,
       async (node?: StarredGistNode | FollowedUserGistNode) => {
-        await ensureAuthenticated();
-
         if (node) {
           const forks = await getForks(node.gist.id);
 
           const items = sortGists(forks).map((g) => ({
-            label: getGistLabel(g),
+            label: `${g.owner.login} / ${getGistLabel(g)}`,
             description: getGistDescription(g),
             owner: g.owner.login,
             id: g.id
@@ -395,10 +429,6 @@ export async function registerGistCommands(context: ExtensionContext) {
           if (selected) {
             openGistFiles(selected.id);
           }
-
-        } else {
-          const message = `Oops, there's an error finding the Gist.`;
-          return window.showInformationMessage(message);
         }
       }
     )
@@ -422,8 +452,8 @@ export async function registerGistCommands(context: ExtensionContext) {
         // don't pass on the tree node object to the open gist method.
         const gistNode =
           node instanceof GistNode ||
-            node instanceof StarredGistNode ||
-            node instanceof FollowedUserGistNode
+          node instanceof StarredGistNode ||
+          node instanceof FollowedUserGistNode
             ? node
             : undefined;
         openGistInternal({ node: gistNode });

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -5,7 +5,13 @@ import * as config from "../config";
 import { ZERO_WIDTH_SPACE } from "../constants";
 import { newTempGist } from "../fileSystem/temp";
 import { log } from "../logger";
-import { byteArrayToString, fileNameToUri, isTempGistId, openGistFiles, sortGists } from "../utils";
+import {
+  byteArrayToString,
+  fileNameToUri,
+  isTempGistId,
+  openGistFiles,
+  sortGists
+} from "../utils";
 import { getToken } from "./auth";
 import { storage } from "./storage";
 
@@ -162,8 +168,6 @@ export async function forkGist(id: string) {
 export async function getForks(id: string) {
   const api = await getApi();
   const response = await api.forks(id);
-
-  console.log(response.body);
 
   return response.body.sort(
     (a: Gist, b: Gist) => Date.parse(b.updated_at) - Date.parse(a.updated_at)

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -5,13 +5,7 @@ import * as config from "../config";
 import { ZERO_WIDTH_SPACE } from "../constants";
 import { newTempGist } from "../fileSystem/temp";
 import { log } from "../logger";
-import {
-  byteArrayToString,
-  fileNameToUri,
-  isTempGistId,
-  openGistFiles,
-  sortGists
-} from "../utils";
+import { byteArrayToString, fileNameToUri, isTempGistId, openGistFiles, sortGists } from "../utils";
 import { getToken } from "./auth";
 import { storage } from "./storage";
 
@@ -163,6 +157,17 @@ export async function forkGist(id: string) {
   store.gists.unshift(gist.body);
 
   openGistFiles(gist.body.id);
+}
+
+export async function getForks(id: string) {
+  const api = await getApi();
+  const response = await api.forks(id);
+
+  console.log(response.body);
+
+  return response.body.sort(
+    (a: Gist, b: Gist) => Date.parse(b.updated_at) - Date.parse(a.updated_at)
+  );
 }
 
 export async function getGist(id: string): Promise<Gist> {

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 const webpack = require("webpack");
 
 const config = {
-  mode: "development",
+  mode: "production",
   target: "node",
   entry: "./src/extension.ts",
   output: {


### PR DESCRIPTION
Allows user to right click on a Gist and view all forks, or get an error toast if it hasn't been forked yet.
Fixes https://github.com/vsls-contrib/gistpad/issues/98

Additional todo: 
1. Change Quickpick menu to include username of person who forked the Gist. 
2. Investigate whether it's possible to determine if a given Gist is a fork of another Gist.