### PR TITLE
Fix typo: SEPERATOR -> SEPARATOR.

### DIFF
--- a/src/abstractions/node/images/pasteImageAsFile.ts
+++ b/src/abstractions/node/images/pasteImageAsFile.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as config from "../../../config";
-import { DIRECTORY_SEPERATOR } from "../../../constants";
+import { DIRECTORY_SEPARATOR } from "../../../constants";
 import { store } from "../../../store";
 import {
   encodeDirectoryName,
@@ -14,7 +14,7 @@ import { pasteImageMarkup } from "./utils/pasteImageMarkup";
 function getImageFileName() {
   const uploadDirectory = config.get("images.directoryName");
   const prefix = uploadDirectory
-    ? `${uploadDirectory}${DIRECTORY_SEPERATOR}`
+    ? `${uploadDirectory}${DIRECTORY_SEPARATOR}`
     : "";
 
   const dateSting = new Date().toDateString().replace(/\s/g, "_");

--- a/src/commands/directory.ts
+++ b/src/commands/directory.ts
@@ -3,8 +3,8 @@ import * as path from "path";
 import { URL } from "url";
 import { commands, ExtensionContext, window, workspace } from "vscode";
 import {
-  DIRECTORY_SEPERATOR,
-  ENCODED_DIRECTORY_SEPERATOR,
+  DIRECTORY_SEPARATOR,
+  ENCODED_DIRECTORY_SEPARATOR,
   EXTENSION_NAME
 } from "../constants";
 import { ensureAuthenticated } from "../store/auth";
@@ -20,7 +20,7 @@ function getDirectoryFiles(nodes: GistDirectoryNode[]) {
   return nodes.flatMap((node) =>
     Object.keys(node.gist.files)
       .filter((file) =>
-        file.startsWith(`${node.directory}${ENCODED_DIRECTORY_SEPERATOR}`)
+        file.startsWith(`${node.directory}${ENCODED_DIRECTORY_SEPARATOR}`)
       )
       .map((file) => decodeDirectoryUri(fileNameToUri(node.gist.id, file)))
   );
@@ -47,7 +47,7 @@ export function registerDirectoryCommands(context: ExtensionContext) {
                 return workspace.fs.writeFile(
                   fileNameToUri(
                     node.gist.id,
-                    `${node.directory}${DIRECTORY_SEPERATOR}${fileName}`
+                    `${node.directory}${DIRECTORY_SEPARATOR}${fileName}`
                   ),
                   stringToByteArray("")
                 );
@@ -77,7 +77,7 @@ export function registerDirectoryCommands(context: ExtensionContext) {
                 const fileName = path.basename(file.path);
                 const content = fs.readFileSync(new URL(file.toString()));
 
-                const gistFileName = `${node.directory}${DIRECTORY_SEPERATOR}${fileName}`;
+                const gistFileName = `${node.directory}${DIRECTORY_SEPARATOR}${fileName}`;
                 return workspace.fs.writeFile(
                   fileNameToUri(node.gist.id, gistFileName),
                   content
@@ -147,7 +147,7 @@ export function registerDirectoryCommands(context: ExtensionContext) {
           Promise.all(
             uris.map(async (uri) => {
               const contents = await workspace.fs.readFile(uri);
-              const duplicateFileName = `${directory}${DIRECTORY_SEPERATOR}${path.basename(
+              const duplicateFileName = `${directory}${DIRECTORY_SEPARATOR}${path.basename(
                 uri.path
               )}`;
 
@@ -181,7 +181,7 @@ export function registerDirectoryCommands(context: ExtensionContext) {
           await withProgress(`Renaming directory...`, async () => {
             for (const uri of uris) {
               const fileName = path.basename(uri.path);
-              const newFileName = `${newDirectoryName}${DIRECTORY_SEPERATOR}${fileName}`;
+              const newFileName = `${newDirectoryName}${DIRECTORY_SEPARATOR}${fileName}`;
               const newUri = fileNameToUri(node.gist.id, newFileName);
 
               await workspace.fs.rename(uri, newUri);

--- a/src/commands/playground.ts
+++ b/src/commands/playground.ts
@@ -4,8 +4,8 @@ import * as path from "path";
 import * as vscode from "vscode";
 import * as config from "../config";
 import {
-  DIRECTORY_SEPERATOR,
-  ENCODED_DIRECTORY_SEPERATOR,
+  DIRECTORY_SEPARATOR,
+  ENCODED_DIRECTORY_SEPARATOR,
   EXTENSION_NAME,
   FS_SCHEME,
   INPUT_SCHEME,
@@ -274,7 +274,7 @@ export const getGistFileOfType = (
   }
 
   const prefix = currentTutorialStep
-    ? `#?${currentTutorialStep}[^\/]*${ENCODED_DIRECTORY_SEPERATOR}`
+    ? `#?${currentTutorialStep}[^\/]*${ENCODED_DIRECTORY_SEPARATOR}`
     : "";
 
   const fileCandidates = extensions.map(
@@ -327,8 +327,8 @@ function isPlaygroundDocument(
   }
 
   const prefix = currentTutorialStep
-    ? `${DIRECTORY_SEPERATOR}#?${currentTutorialStep}[^\/]*${DIRECTORY_SEPERATOR}`
-    : DIRECTORY_SEPERATOR;
+    ? `${DIRECTORY_SEPARATOR}#?${currentTutorialStep}[^\/]*${DIRECTORY_SEPARATOR}`
+    : DIRECTORY_SEPARATOR;
 
   const fileCandidates = extensions.map(
     (extension) => new RegExp(`${prefix}${fileBaseName}${extension}`)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,6 @@ export const UNTITLED_SCHEME = "untitled";
 export const URI_PATTERN = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/;
 export const ZERO_WIDTH_SPACE = "‎‎\u200B";
 export const TEMP_GIST_ID = "temp";
-export const DIRECTORY_SEPERATOR = "/";
-export const ENCODED_DIRECTORY_SEPERATOR = "---";
+export const DIRECTORY_SEPARATOR = "/";
+export const ENCODED_DIRECTORY_SEPARATOR = "---";
 export const SCRATCH_GIST_NAME = "gistpad-scratch";

--- a/src/fileSystem/index.ts
+++ b/src/fileSystem/index.ts
@@ -18,8 +18,8 @@ import {
   workspace
 } from "vscode";
 import {
-  DIRECTORY_SEPERATOR,
-  ENCODED_DIRECTORY_SEPERATOR,
+  DIRECTORY_SEPARATOR,
+  ENCODED_DIRECTORY_SEPARATOR,
   EXTENSION_NAME,
   FS_SCHEME,
   ZERO_WIDTH_SPACE
@@ -106,7 +106,7 @@ export class GistFileSystemProvider implements FileSystemProvider {
 
     const prefix = uri.path
       .substr(1)
-      .replace(DIRECTORY_SEPERATOR, ENCODED_DIRECTORY_SEPERATOR);
+      .replace(DIRECTORY_SEPARATOR, ENCODED_DIRECTORY_SEPARATOR);
     return !!Object.keys(gist.files).find((file) => file.startsWith(prefix));
   }
 
@@ -229,8 +229,8 @@ export class GistFileSystemProvider implements FileSystemProvider {
       // @ts-ignore
       const files: [string, FileType][] = Object.keys(gist.files)
         .map((file) => {
-          if (file.includes(ENCODED_DIRECTORY_SEPERATOR)) {
-            const directory = file.split(ENCODED_DIRECTORY_SEPERATOR)[0];
+          if (file.includes(ENCODED_DIRECTORY_SEPARATOR)) {
+            const directory = file.split(ENCODED_DIRECTORY_SEPARATOR)[0];
             return [directory, FileType.Directory];
           } else {
             return [file, FileType.File];
@@ -263,14 +263,14 @@ export class GistFileSystemProvider implements FileSystemProvider {
 
       const prefix = uri.path
         .substr(1)
-        .replace(DIRECTORY_SEPERATOR, ENCODED_DIRECTORY_SEPERATOR);
+        .replace(DIRECTORY_SEPARATOR, ENCODED_DIRECTORY_SEPARATOR);
 
       const files: [string, FileType][] = Object.keys(gist.files)
         .filter((file) => file.startsWith(prefix))
         .map((file) => {
           const updatedFile = file.split(prefix)[1];
-          if (updatedFile.includes(ENCODED_DIRECTORY_SEPERATOR)) {
-            const directory = file.split(ENCODED_DIRECTORY_SEPERATOR)[0];
+          if (updatedFile.includes(ENCODED_DIRECTORY_SEPARATOR)) {
+            const directory = file.split(ENCODED_DIRECTORY_SEPARATOR)[0];
             return [directory, FileType.Directory];
           } else {
             return [updatedFile, FileType.File];
@@ -329,14 +329,14 @@ export class GistFileSystemProvider implements FileSystemProvider {
   }
 
   async stat(uri: Uri): Promise<FileStat> {
-    if (uri.path === DIRECTORY_SEPERATOR) {
+    if (uri.path === DIRECTORY_SEPARATOR) {
       return {
         type: FileType.Directory,
         size: 0,
         ctime: 0,
         mtime: 0
       };
-    } else if (uri.path.endsWith(DIRECTORY_SEPERATOR)) {
+    } else if (uri.path.endsWith(DIRECTORY_SEPARATOR)) {
       if (this.isDirectory(uri)) {
         return {
           type: FileType.Directory,

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -11,7 +11,7 @@ import {
 } from ".";
 import * as config from "../config";
 import {
-  DIRECTORY_SEPERATOR,
+  DIRECTORY_SEPARATOR,
   SCRATCH_GIST_NAME,
   ZERO_WIDTH_SPACE
 } from "../constants";
@@ -281,7 +281,7 @@ export async function newScratchNote() {
 
   const sharedMoment = moment();
   const directory = directoryFormat
-    ? `${sharedMoment.format(directoryFormat)}${DIRECTORY_SEPERATOR}`
+    ? `${sharedMoment.format(directoryFormat)}${DIRECTORY_SEPARATOR}`
     : "";
 
   const file = sharedMoment.format(fileFormat);

--- a/src/tree/nodes.ts
+++ b/src/tree/nodes.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
 import * as config from "../config";
 import {
-  ENCODED_DIRECTORY_SEPERATOR,
+  ENCODED_DIRECTORY_SEPARATOR,
   EXTENSION_NAME,
   TEMP_GIST_ID
 } from "../constants";
@@ -153,8 +153,8 @@ ${suffix}`;
 }
 
 function getFileDisplayName(file: GistFile) {
-  if (file.filename?.includes(ENCODED_DIRECTORY_SEPERATOR)) {
-    return file.filename.split(ENCODED_DIRECTORY_SEPERATOR)[1];
+  if (file.filename?.includes(ENCODED_DIRECTORY_SEPARATOR)) {
+    return file.filename.split(ENCODED_DIRECTORY_SEPARATOR)[1];
   }
 
   return file.filename!;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,8 +11,8 @@ import {
 } from "vscode";
 import { closeWebviewPanel, openPlayground } from "./commands/playground";
 import {
-  DIRECTORY_SEPERATOR,
-  ENCODED_DIRECTORY_SEPERATOR,
+  DIRECTORY_SEPARATOR,
+  ENCODED_DIRECTORY_SEPARATOR,
   FS_SCHEME,
   INPUT_SCHEME,
   PLAYGROUND_FILE,
@@ -187,28 +187,28 @@ export async function openGistFile(uri: Uri, allowPreview: boolean = true) {
 }
 
 export function encodeDirectoryName(filename: string) {
-  return filename.replace(DIRECTORY_SEPERATOR, ENCODED_DIRECTORY_SEPERATOR);
+  return filename.replace(DIRECTORY_SEPARATOR, ENCODED_DIRECTORY_SEPARATOR);
 }
 
 export function decodeDirectoryName(filename: string) {
-  return filename.replace(ENCODED_DIRECTORY_SEPERATOR, DIRECTORY_SEPERATOR);
+  return filename.replace(ENCODED_DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
 }
 
 export function encodeDirectoryUri(uri: Uri) {
-  if (uri.path.substr(1).includes(DIRECTORY_SEPERATOR)) {
+  if (uri.path.substr(1).includes(DIRECTORY_SEPARATOR)) {
     return uri.with({
-      path: `${DIRECTORY_SEPERATOR}${uri.path
+      path: `${DIRECTORY_SEPARATOR}${uri.path
         .substr(1)
-        .replace(DIRECTORY_SEPERATOR, ENCODED_DIRECTORY_SEPERATOR)}`
+        .replace(DIRECTORY_SEPARATOR, ENCODED_DIRECTORY_SEPARATOR)}`
     });
   }
   return uri;
 }
 
 export function decodeDirectoryUri(uri: Uri) {
-  if (uri.path.includes(ENCODED_DIRECTORY_SEPERATOR)) {
+  if (uri.path.includes(ENCODED_DIRECTORY_SEPARATOR)) {
     return uri.with({
-      path: uri.path.replace(ENCODED_DIRECTORY_SEPERATOR, DIRECTORY_SEPERATOR)
+      path: uri.path.replace(ENCODED_DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)
     });
   }
   return uri;
@@ -220,8 +220,8 @@ export function fileNameToUri(gistId: string, filename: string = ""): Uri {
 
 export function getGistDetailsFromUri(uri: Uri) {
   const pathWithoutPrefix = uri.path.substr(1);
-  const directory = pathWithoutPrefix.includes(DIRECTORY_SEPERATOR)
-    ? pathWithoutPrefix.split(DIRECTORY_SEPERATOR)[0]
+  const directory = pathWithoutPrefix.includes(DIRECTORY_SEPARATOR)
+    ? pathWithoutPrefix.split(DIRECTORY_SEPARATOR)[0]
     : "";
 
   return {


### PR DESCRIPTION
Corrects a typo in `DIRECTORY_SEPERATOR` and `ENCODED_DIRECTORY_SEPERATOR`, renaming them to `DIRECTORY_SEPARATOR` and `ENCODED_DIRECTORY_SEPERATOR`.