### PR TITLE
making it clearer that a gist will be public

### DIFF
--- a/src/commands/editor.ts
+++ b/src/commands/editor.ts
@@ -32,7 +32,7 @@ async function askForFileName() {
   });
 }
 
-const CREATE_PUBLIC_GIST_ITEM = "$(gist-new) Create new Gist...";
+const CREATE_PUBLIC_GIST_ITEM = "$(gist-new) Create new public Gist...";
 const CREATE_SECRET_GIST_ITEM = "$(gist-private) Create new secret Gist...";
 const CREATE_GIST_ITEMS = [
   { label: CREATE_PUBLIC_GIST_ITEM, alwaysShow: true },

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -123,7 +123,7 @@ async function newGistInternal(isPublic: boolean = true) {
 }
 
 const SIGN_IN_ITEM = "Sign in to view Gists...";
-const CREATE_PUBLIC_GIST_ITEM = "$(gist-new) Create new Gist...";
+const CREATE_PUBLIC_GIST_ITEM = "$(gist-new) Create new public Gist...";
 const CREATE_SECRET_GIST_ITEM = "$(gist-private) Create new secret Gist...";
 const STARRED_GIST_ITEM = "$(star) View starred Gists...";
 const CREATE_GIST_ITEMS = [
@@ -300,7 +300,7 @@ export async function registerGistCommands(context: ExtensionContext) {
         // in it, and the API doesn't support that URL format
         const url = `https://gist.github.com/${node.gist.owner!.login}/${
           node.gist.id
-        }`;
+          }`;
         env.clipboard.writeText(url);
       }
     )
@@ -470,8 +470,8 @@ export async function registerGistCommands(context: ExtensionContext) {
         // don't pass on the tree node object to the open gist method.
         const gistNode =
           node instanceof GistNode ||
-          node instanceof StarredGistNode ||
-          node instanceof FollowedUserGistNode
+            node instanceof StarredGistNode ||
+            node instanceof FollowedUserGistNode
             ? node
             : undefined;
         openGistInternal({ node: gistNode });


### PR DESCRIPTION
**This PR fixes Issue#**
n/a

**Description of the PR**:
Adding "public" to the command description. This makes it clearer and remiinds users that the gist will be public. I recently mistakenly made a gist public when it shouldn't have been, so thought this might prevent others from making hte same mistake.


**Additional context**:
n/a